### PR TITLE
Add autofocus param to textarea

### DIFF
--- a/src/cljs/reagent_form/components/input.cljs
+++ b/src/cljs/reagent_form/components/input.cljs
@@ -30,7 +30,8 @@
         params
         (second node)
 
-        {:keys [default-errors
+        {:keys [auto-focus
+                default-errors
                 default-hints
                 default-value
                 field-key
@@ -102,6 +103,9 @@
                                [1]
                                assoc
                                :value field-value)
+
+              (true? auto-focus)
+              (assoc-in [1 :auto-focus true])
 
               (= type :checkbox)
               (assoc-in [1 :checked] field-value)

--- a/src/cljs/reagent_form/core.cljs
+++ b/src/cljs/reagent_form/core.cljs
@@ -156,12 +156,13 @@
                                 :type]))]))
 
 (defn textarea
-  [{:keys [field-key] :as params}]
+  [{:keys [field-key auto-focus] :as params :or {auto-focus false}}]
   (form-field
    params
    [:textarea
     (merge {:rf/input (select-keys params rf-input-params)}
            (select-keys params [:class
+                                :auto-focus
                                 :id
                                 :placeholder
                                 :style]))]))


### PR DESCRIPTION
Allows users to specify a param to autofocus on an input. 